### PR TITLE
Update message.js DOM text reinterpreted as HTML

### DIFF
--- a/misc/message.js
+++ b/misc/message.js
@@ -44,7 +44,7 @@
         wrapper.setAttribute('data-drupal-messages', '');
         wrapper.classList.remove('hidden');
       }
-      return wrapper.innerHTML === ''
+      return wrapper.innerText === ''
         ? Drupal.Message.messageInternalWrapper(wrapper)
         : wrapper.firstElementChild;
     }


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.

