### PR TITLE
Update message.js-2 DOM text reinterpreted as HTML

### DIFF
--- a/misc/message.js
+++ b/misc/message.js
@@ -247,7 +247,7 @@
 
     messageWrapper.setAttribute('aria-label', messagesTypes[type]);
 
-    messageWrapper.innerHTML = `${text}`;
+    messageWrapper.innerText = `${text}`;
 
     return messageWrapper;
   };


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.