### PR TITLE
Fix inconsistent switch case syntax

### DIFF
--- a/modules/field/src/FieldConfigStorage.php
+++ b/modules/field/src/FieldConfigStorage.php
@@ -150,11 +150,11 @@ class FieldConfigStorage extends FieldConfigStorageBase {
             $checked_value = $field_storage->uuid();
             break;
 
-          case 'uuid';
+          case 'uuid':
             $checked_value = $field->uuid();
             break;
 
-          case 'deleted';
+          case 'deleted':
             $checked_value = $field->isDeleted();
             break;
 

--- a/modules/field/src/Plugin/migrate/process/d6/FieldInstanceOptionTranslation.php
+++ b/modules/field/src/Plugin/migrate/process/d6/FieldInstanceOptionTranslation.php
@@ -30,7 +30,7 @@ class FieldInstanceOptionTranslation extends ProcessPluginBase {
       $list = array_map('trim', $list);
       $list = FilterArray::removeEmptyStrings($list);
       switch ($field_type) {
-        case 'boolean';
+        case 'boolean':
           $option = preg_replace('/^option_/', '', $row->getSourceProperty('property'));
           for ($i = 0; $i < 2; $i++) {
             $value = $list[$i];

--- a/modules/field/src/Plugin/migrate/process/d7/FieldInstanceOptionTranslation.php
+++ b/modules/field/src/Plugin/migrate/process/d7/FieldInstanceOptionTranslation.php
@@ -29,7 +29,7 @@ class FieldInstanceOptionTranslation extends ProcessPluginBase {
     if (isset($data['settings']['allowed_values'])) {
       $allowed_values = $data['settings']['allowed_values'];
       switch ($type) {
-        case 'boolean';
+        case 'boolean':
           if (isset($allowed_values[$property])) {
             $translation = $row->getSourceProperty('translation');
             break;

--- a/modules/jsonapi/tests/src/Functional/CommentTest.php
+++ b/modules/jsonapi/tests/src/Functional/CommentTest.php
@@ -293,10 +293,10 @@ class CommentTest extends ResourceTestBase {
    */
   protected function getExpectedUnauthorizedAccessMessage($method) {
     switch ($method) {
-      case 'GET';
+      case 'GET':
         return "The 'access comments' permission is required and the comment must be published.";
 
-      case 'POST';
+      case 'POST':
         return "The 'post comments' permission is required.";
 
       case 'PATCH':

--- a/modules/jsonapi/tests/src/Functional/MediaTest.php
+++ b/modules/jsonapi/tests/src/Functional/MediaTest.php
@@ -323,7 +323,7 @@ class MediaTest extends ResourceTestBase {
    */
   protected function getExpectedUnauthorizedAccessMessage($method) {
     switch ($method) {
-      case 'GET';
+      case 'GET':
         return "The 'view media' permission is required when the media item is published.";
 
       case 'POST':

--- a/modules/language/src/Plugin/migrate/process/ContentTranslationEnabledSetting.php
+++ b/modules/language/src/Plugin/migrate/process/ContentTranslationEnabledSetting.php
@@ -32,7 +32,7 @@ class ContentTranslationEnabledSetting extends ProcessPluginBase {
     switch ($language_content_type) {
       // In the case of being 0, it will be skipped. We are not actually setting
       // a null value.
-      case 0;
+      case 0:
         $setting = NULL;
         break;
 

--- a/modules/media/tests/src/Functional/Rest/MediaResourceTestBase.php
+++ b/modules/media/tests/src/Functional/Rest/MediaResourceTestBase.php
@@ -292,7 +292,7 @@ abstract class MediaResourceTestBase extends EntityResourceTestBase {
    */
   protected function getExpectedUnauthorizedAccessMessage($method) {
     switch ($method) {
-      case 'GET';
+      case 'GET':
         return "The 'view media' permission is required when the media item is published.";
 
       case 'POST':

--- a/modules/user/src/EventSubscriber/AccessDeniedSubscriber.php
+++ b/modules/user/src/EventSubscriber/AccessDeniedSubscriber.php
@@ -64,12 +64,12 @@ class AccessDeniedSubscriber extends HttpExceptionSubscriberBase {
     $redirect_url = NULL;
     if ($this->account->isAuthenticated()) {
       switch ($route_name) {
-        case 'user.login';
+        case 'user.login':
           // Redirect an authenticated user to the profile page.
           $redirect_url = Url::fromRoute('entity.user.canonical', ['user' => $this->account->id()], ['absolute' => TRUE]);
           break;
 
-        case 'user.register';
+        case 'user.register':
           // Redirect an authenticated user to the profile form.
           $redirect_url = Url::fromRoute('entity.user.edit_form', ['user' => $this->account->id()], ['absolute' => TRUE]);
           break;

--- a/modules/views/src/Plugin/views/sort/SortPluginBase.php
+++ b/modules/views/src/Plugin/views/sort/SortPluginBase.php
@@ -68,8 +68,8 @@ abstract class SortPluginBase extends HandlerBase implements CacheableDependency
       default:
         return $this->t('asc');
 
-      case 'DESC';
-      case 'desc';
+      case 'DESC':
+      case 'desc':
         return $this->t('desc');
     }
   }

--- a/tests/Drupal/KernelTests/Config/DefaultConfigTest.php
+++ b/tests/Drupal/KernelTests/Config/DefaultConfigTest.php
@@ -86,7 +86,7 @@ class DefaultConfigTest extends KernelTestBase {
         $file_name = DRUPAL_ROOT . '/core/modules/system/tests/modules/' . $name . '/' . $name . '.info.yml';
         break;
 
-      default;
+      default:
         $file_name = DRUPAL_ROOT . '/core/' . $type . 's/' . $name . '/' . $name . '.info.yml';
     }
 


### PR DESCRIPTION
It seems that these were unintentional typos, since they are mixed in with case statements using the standard syntax.